### PR TITLE
fix: correct stale/inaccurate docs before public traffic

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ npm run test:watch
 
 | Variable | Required | Description |
 |----------|----------|-------------|
-| `CORTEX_API_TOKEN` | Yes | Authentication token for the HTTP API |
+| `CORTEX_API_TOKEN` | Optional | Used by the `cortex-telemetry` hook to send retrieval feedback to the cortex API. Not required to run the MCP server. |
 
 Additional variables are required depending on which providers you enable (Firestore, Vertex AI, OpenAI, etc.). See `docs/` for provider-specific configuration.
 

--- a/docs/digest-watcher-design.md
+++ b/docs/digest-watcher-design.md
@@ -4,6 +4,8 @@ type: spec
 status: draft
 ---
 
+> **Status: Not yet implemented.** This is a design document for a planned `fozikio watch` command. The feature does not exist yet. Use `fozikio digest <file>` for manual invocation.
+
 # Digest File Watcher — Design Brief
 
 ## Problem

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -70,7 +70,7 @@ Edit `.fozikio/agent.yaml` to change:
 | Setting | Options | Default |
 |---------|---------|---------|
 | Storage | `sqlite`, `firestore` | `sqlite` |
-| Embeddings | `ollama`, `vertex`, `openai` | `ollama` |
+| Embeddings | `built-in`, `ollama`, `vertex`, `openai` | `built-in` |
 | LLM | `ollama`, `gemini`, `anthropic`, `openai` | `ollama` |
 
 ```bash
@@ -79,12 +79,13 @@ npx fozikio config --store sqlite --embed ollama --llm ollama
 
 ## Local defaults
 
-Out of the box, cortex-engine uses **SQLite** (local file) and **Ollama** (local models). No cloud accounts needed.
+Out of the box, cortex-engine uses **SQLite** (local file) and **built-in** embeddings (no external model needed). No cloud accounts required.
 
-To use Ollama, install it from [ollama.com](https://ollama.com) and pull an embedding model:
+To use Ollama instead, install it from [ollama.com](https://ollama.com), pull an embedding model, and set `--embed ollama`:
 
 ```bash
 ollama pull nomic-embed-text
+npx fozikio config --embed ollama
 ```
 
 ## Next steps

--- a/fozikio.json
+++ b/fozikio.json
@@ -1,6 +1,6 @@
 {
   "name": "cortex-engine",
-  "version": "0.1.0",
+  "version": "0.4.0",
   "description": "Portable agent infrastructure for cortex-powered AI agents",
   "requires": {
     "cortex_api": ">=0.3.0",


### PR DESCRIPTION
- CORTEX_API_TOKEN: was listed as Required but is optional (telemetry hook only)
- quick-start.md: embed default was wrong (ollama → built-in); built-in option was missing from table
- digest-watcher-design.md: added prominent not-yet-implemented notice so readers don't expect fozikio watch to exist
- fozikio.json: sync version 0.1.0 → 0.4.0 to match package.json

https://claude.ai/code/session_017gT8rSQhqXvGUsSvzaELLf