### PR TITLE
Potential fix for code scanning alert no. 2: Code injection

### DIFF
--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -91,9 +91,9 @@ jobs:
       - name: Notify dependabot PR
         env:
           NTFY_TOKEN: ${{ secrets.NTFY_TOKEN }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
           PR_NUM="${{ github.event.pull_request.number }}"
-          PR_TITLE="${{ github.event.pull_request.title }}"
 
           curl -s \
             -H "Authorization: Bearer $NTFY_TOKEN" \


### PR DESCRIPTION
Potential fix for [https://github.com/Fozikio/cortex-engine/security/code-scanning/2](https://github.com/Fozikio/cortex-engine/security/code-scanning/2)

To fix the problem, we should stop interpolating the untrusted PR title into the shell script using the GitHub expression syntax and instead pass it via an environment variable, then read it using native shell variable syntax. This follows GitHub’s recommended mitigation pattern and prevents the shell from interpreting any injected content as code.

Concretely, in `.github/workflows/notify.yml`, in the `dependabot-pr` job’s `Notify dependabot PR` step, we should:
- Move `github.event.pull_request.title` out of the script and into the `env:` block, e.g. `PR_TITLE: ${{ github.event.pull_request.title }}`.
- In the script, remove the line `PR_TITLE="${{ github.event.pull_request.title }}"`, leaving `PR_TITLE` to be populated from the environment.
- Continue to use `"$PR_TITLE"` in the `curl -d` payload; this safely expands the environment variable without involving GitHub’s expression syntax inside the script.

We will leave the `PR_NUM` assignment as-is because it is derived from the PR number (numeric, not attacker-controlled content in a way that could meaningfully influence shell parsing), and the CodeQL alert is specifically about the `title`. No new methods or external libraries are needed; we only adjust the YAML `env:` block and the shell variable assignment within the shown step.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
