### PR TITLE
Potential fix for code scanning alert no. 1: Code injection

### DIFF
--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -48,11 +48,11 @@ jobs:
       - name: Notify review submitted
         env:
           NTFY_TOKEN: ${{ secrets.NTFY_TOKEN }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
           REVIEWER="${{ github.event.review.user.login }}"
           STATE="${{ github.event.review.state }}"
           PR_NUM="${{ github.event.pull_request.number }}"
-          PR_TITLE="${{ github.event.pull_request.title }}"
 
           case "$STATE" in
             approved)


### PR DESCRIPTION
Potential fix for [https://github.com/Fozikio/cortex-engine/security/code-scanning/1](https://github.com/Fozikio/cortex-engine/security/code-scanning/1)

General approach: Avoid using untrusted `${{ ... }}` expressions directly inside shell scripts in `run:`. Instead, map untrusted event data into environment variables at the step level using `${{ ... }}` and then reference them inside the script using plain shell syntax (`$VAR`). This prevents an attacker from breaking the shell script structure via expression injection.

Best concrete fix here: move `github.event.pull_request.title` into an environment variable in the `Notify review submitted` step, alongside `NTFY_TOKEN`. Then, in the `run:` script, replace the direct GitHub expression in the assignment with a normal shell reference. Specifically:

- In the `Notify review submitted` step (around line 48–56), extend the `env:` block to include a new key, e.g. `PR_TITLE: ${{ github.event.pull_request.title }}`.
- Change the line `PR_TITLE="${{ github.event.pull_request.title }}"` inside the `run:` block to `PR_TITLE="$PR_TITLE"` or simply rely on `$PR_TITLE` directly where needed. To minimize functional changes and keep the structure similar, using `PR_TITLE="$PR_TITLE"` is fine, but we can also just drop the explicit assignment and use `$PR_TITLE` where the title is needed.
- Update no other behavior; all later uses of `PR_TITLE` remain the same, just now populated via the environment instead of direct expression injection.

No new methods or external libraries are required; all changes are confined to `.github/workflows/notify.yml` in the `review-submitted` job, in the `Notify review submitted` step’s `env:` and `run:` sections.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
