### PR TITLE
fix: resolve code scanning alerts + CI type-check failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches: [master]
 
+permissions:
+  contents: read
+
 jobs:
   typecheck:
     name: Type Check

--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -25,6 +25,7 @@ jobs:
       github.event.check_suite.conclusion == 'failure' &&
       github.event.check_suite.pull_requests[0]
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - name: Notify CI failure
         env:
@@ -44,6 +45,7 @@ jobs:
   review-submitted:
     if: github.event_name == 'pull_request_review'
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - name: Notify review submitted
         env:
@@ -87,6 +89,7 @@ jobs:
       github.event_name == 'pull_request_target' &&
       github.event.pull_request.user.login == 'dependabot[bot]'
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - name: Notify dependabot PR
         env:

--- a/src/bridges/bridge.ts
+++ b/src/bridges/bridge.ts
@@ -32,7 +32,7 @@ export interface BridgeResult {
  */
 export function evaluateCondition(condition: string, data: Record<string, unknown>): boolean {
   // Parse: field operator value
-  const match = condition.match(/^\s*(\w+)\s*(==|!=|>=|<=|>|<)\s*(.+?)$/);
+  const match = condition.trim().match(/^(\w+)\s*(==|!=|>=|<=|>|<)\s*(.+)$/);
   if (!match) return false;
 
   const [, field, op, rawValue] = match;

--- a/src/bridges/bridge.ts
+++ b/src/bridges/bridge.ts
@@ -31,11 +31,16 @@ export interface BridgeResult {
  *   "dimension == \"beliefs\""
  */
 export function evaluateCondition(condition: string, data: Record<string, unknown>): boolean {
-  // Parse: field operator value
-  const match = condition.trim().match(/^(\w+)\s*(==|!=|>=|<=|>|<)\s*(.+)$/);
-  if (!match) return false;
-
-  const [, field, op, rawValue] = match;
+  // Parse: field operator value (no regex on uncontrolled input to avoid ReDoS)
+  const s = condition.trim();
+  const fieldMatch = s.match(/^(\w+)/);
+  if (!fieldMatch) return false;
+  const field = fieldMatch[1];
+  let rest = s.slice(field.length).trimStart();
+  const opMatch = rest.match(/^(==|!=|>=|<=|>|<)/);
+  if (!opMatch) return false;
+  const op = opMatch[1];
+  const rawValue = rest.slice(op.length).trimStart();
   const actual = data[field];
   if (actual === undefined) return false;
 

--- a/src/bridges/bridge.ts
+++ b/src/bridges/bridge.ts
@@ -32,7 +32,7 @@ export interface BridgeResult {
  */
 export function evaluateCondition(condition: string, data: Record<string, unknown>): boolean {
   // Parse: field operator value
-  const match = condition.match(/^\s*(\w+)\s*(==|!=|>=|<=|>|<)\s*(.+)\s*$/);
+  const match = condition.match(/^\s*(\w+)\s*(==|!=|>=|<=|>|<)\s*(.+?)$/);
   if (!match) return false;
 
   const [, field, op, rawValue] = match;

--- a/src/engines/keywords.ts
+++ b/src/engines/keywords.ts
@@ -41,7 +41,7 @@ export function extractKeywords(text: string, max: number = 20): string[] {
         .toLowerCase()
         .replace(/[^a-z0-9\s'-]/g, ' ')
         .split(/\s+/)
-        .map(w => w.replace(/^['-]+/, '').replace(/['-]+$/, ''))
+        .map(w => { let s = 0, e = w.length; while (s < e && (w[s]==="'"||w[s]==="-")) s++; while (e > s && (w[e-1]==="'"||w[e-1]==="-")) e--; return w.slice(s, e); })
         .filter(w => w.length >= 3 && !STOP_WORDS.has(w) && !/^\d+$/.test(w))
     ),
   ].slice(0, max);

--- a/src/engines/keywords.ts
+++ b/src/engines/keywords.ts
@@ -41,7 +41,7 @@ export function extractKeywords(text: string, max: number = 20): string[] {
         .toLowerCase()
         .replace(/[^a-z0-9\s'-]/g, ' ')
         .split(/\s+/)
-        .map(w => w.replace(/^['-]+|['-]+$/g, ''))
+        .map(w => w.replace(/^['-]+/, '').replace(/['-]+$/, ''))
         .filter(w => w.length >= 3 && !STOP_WORDS.has(w) && !/^\d+$/.test(w))
     ),
   ].slice(0, max);

--- a/src/providers/builtin-embed.ts
+++ b/src/providers/builtin-embed.ts
@@ -19,6 +19,7 @@ async function getPipeline() {
 
   let createPipeline;
   try {
+    // @ts-expect-error — optional peer dependency, dynamically loaded
     ({ pipeline: createPipeline } = await import('@huggingface/transformers'));
   } catch {
     throw new Error(

--- a/src/providers/builtin-embed.ts
+++ b/src/providers/builtin-embed.ts
@@ -1,11 +1,11 @@
 /**
- * BuiltInEmbedProvider — zero-dependency local embeddings using @huggingface/transformers.
+ * BuiltInEmbedProvider — local embeddings using @huggingface/transformers (optional peer dependency).
  *
  * Uses all-MiniLM-L6-v2 (23MB, 384 dimensions) by default.
  * No Ollama, no API keys, no external services needed.
  * Model is downloaded on first use and cached locally.
  *
- * This is the default embed provider — works immediately after npm install.
+ * Requires: `npm install @huggingface/transformers`
  */
 
 import type { EmbedProvider } from '../core/embed.js';
@@ -19,7 +19,7 @@ async function getPipeline() {
 
   let createPipeline;
   try {
-    // @ts-expect-error — optional peer dependency, dynamically loaded
+    // @ts-ignore — optional peer dependency, may or may not be installed
     ({ pipeline: createPipeline } = await import('@huggingface/transformers'));
   } catch {
     throw new Error(

--- a/src/rest/server.ts
+++ b/src/rest/server.ts
@@ -536,9 +536,7 @@ export async function startRestServer(
       if (message.includes('not available')) {
         errorJson(res, message, 404);
       } else {
-        // Log full error server-side but return generic message to client
-        // to avoid leaking internal details (stack traces, file paths, etc.)
-        process.stderr.write(`[cortex] Internal error: ${message}\n`);
+        process.stderr.write(`[rest] unhandled error: ${err instanceof Error ? err.stack ?? message : message}\n`);
         errorJson(res, 'Internal server error', 500);
       }
     }


### PR DESCRIPTION
## Summary

- Fix 2 ReDoS vulnerabilities in regex patterns (keywords.ts, bridge.ts)
- Fix stack trace exposure in REST error handler (server.ts) 
- Add minimal workflow permissions to ci.yml and notify.yml
- Fix CI type-check failure: @huggingface/transformers moved to optional peerDependencies by Dependabot merge

## Alerts Resolved

| # | Severity | File | Issue |
|---|----------|------|-------|
| 9 | HIGH | keywords.ts:44 | Polynomial ReDoS on `'` repetitions |
| 8 | HIGH | bridge.ts:35 | Polynomial ReDoS on trailing spaces |
| 7 | MEDIUM | server.ts:116 | Stack trace leaked to API clients |
| 6,5,4 | MEDIUM | notify.yml | Missing workflow permissions |
| 3 | MEDIUM | ci.yml | Missing workflow permissions |

## CI Fix

`@huggingface/transformers` was moved to optional peerDependencies in the Dependabot lockfile update (#14), breaking `tsc`. Added `@ts-expect-error` for the dynamic import which already has a runtime try/catch fallback.

## Test plan

- [ ] CI passes (type-check + build)
- [ ] Code scanning alerts close automatically after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)