### PR TITLE
Potential fix for code scanning alert no. 7: Information exposure through a stack trace

### DIFF
--- a/src/rest/server.ts
+++ b/src/rest/server.ts
@@ -534,7 +534,9 @@ export async function startRestServer(
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       if (message.includes('not available')) {
-        errorJson(res, message, 404);
+        // Log detailed error information on the server, but return a generic message to the client.
+        process.stderr.write(`[rest] not available error: ${err instanceof Error ? err.stack ?? message : message}\n`);
+        errorJson(res, 'Resource not available', 404);
       } else {
         process.stderr.write(`[rest] unhandled error: ${err instanceof Error ? err.stack ?? message : message}\n`);
         errorJson(res, 'Internal server error', 500);


### PR DESCRIPTION
Potential fix for [https://github.com/Fozikio/cortex-engine/security/code-scanning/7](https://github.com/Fozikio/cortex-engine/security/code-scanning/7)

To fix the problem, we should stop returning raw exception messages derived from `err` to the client, and instead send generic, non‑sensitive messages while logging detailed information (including message and stack) only on the server. This applies particularly to the branch currently sending `message` when it contains `"not available"`.

Concretely, in `src/rest/server.ts`:

1. In the `catch` block around `await match.handler(...)` (lines 532–541), change the handling of the `"not available"` case:
   - Keep the logic that treats this as a 404, but no longer send the raw `message` to the user.
   - Instead, send a generic message like `'Resource not available'` or `'Not found'`.
   - Log the original error details (including `message` and `err.stack`) to `process.stderr`, similar to the existing logging in the `else` branch.

2. Keep using `errorJson` and `json` as they are; the issue is not with these helpers themselves, but with what data we pass into them. By ensuring we only pass generic, non‑tainted strings derived from constants (not from `err`), we break the taint flow to the HTTP response.

No new methods or imports are strictly required; we can reuse `process.stderr.write` for logging. All changes are localized to the shown `catch` block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
