### PR TITLE
fix(deps): patch critical websocket-driver vulnerability (Dependabot blind spot)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5146,9 +5146,9 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/websocket-driver": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
-      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.5.tgz",
+      "integrity": "sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {


### PR DESCRIPTION
## Summary
- `npm audit` flags a **critical** severity issue in `websocket-driver@<=0.7.4` (pulled in transitively via `firebase-admin -> @firebase/database-compat -> @firebase/database -> faye-websocket`): resource-limit bypass ([GHSA-mp7j-qc5w-4988](https://github.com/advisories/GHSA-mp7j-qc5w-4988)) and message corruption ([GHSA-xv26-6w52-cph6](https://github.com/advisories/GHSA-xv26-6w52-cph6)).
- Dependabot has never generated an alert for this — same dependency-graph blind spot as the hono issue found in tools-content/evolution/social/reasoning on 2026-07-09.
- Fix is lockfile-only (`npm audit fix` -> websocket-driver 0.7.4 -> 0.7.5), no `package.json` version bump needed for this repo's own version.

## Test plan
- [x] `npm ci && npm run build` — 0 errors
- [x] `npm audit` — 0 vulnerabilities after fix (was 1 critical)

Found during scheduled ecosystem health check (2026-07-16), running unattended — opened as a PR rather than merged directly so a human can review before it lands on `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)