### PR TITLE
docs: document the @hono/node-server advisory chain in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,24 @@ The engine includes defense-in-depth protections for deployed environments:
 - **SQLite injection prevention** — namespace names are validated (alphanumeric only), LIMIT clauses are parameterized
 - **Secret leak prevention** — config loader warns when API keys appear in config files instead of environment variables
 
+### Known advisories
+
+`npm install @fozikio/cortex-engine` currently reports **3 moderate advisories**. All three are the same upstream issue counted at three levels of one dependency chain, and none are reachable in this package:
+
+```
+@fozikio/cortex-engine
+└── @modelcontextprotocol/sdk@1.29.0   (latest)
+    └── @hono/node-server ^1.19.9      ← GHSA-frvp-7c67-39w9
+```
+
+**What it is:** path traversal in `@hono/node-server`'s `serve-static` middleware on Windows, via an encoded backslash (`%5C`).
+
+**Why it isn't fixed:** the advisory's first patched version is `2.0.5` — a major-version bump the MCP SDK has not taken. `@modelcontextprotocol/sdk@1.29.0` is the current latest and still pins `^1.19.9`, so there is no remediation available downstream. Forcing `2.x` via an override would break the SDK's expected API.
+
+**Why it doesn't affect you:** cortex-engine never imports hono. `@hono/node-server` is pulled in only as a transitive dependency of the MCP SDK, and the MCP server here runs over **stdio transport**, which never mounts `serve-static`. The dashboard's static file serving is our own implementation ([`src/rest/server.ts`](src/rest/server.ts)), which resolves paths and verifies containment with `path.relative` before reading — explicitly handling the Windows backslash case this advisory describes.
+
+This will clear on its own once the MCP SDK adopts `@hono/node-server` 2.x. Until then, `npm audit` noise from this chain is expected and safe to ignore.
+
 ## Architecture
 
 | Module | Role |


### PR DESCRIPTION
`npm install @fozikio/cortex-engine` reports 3 moderate advisories to every user. All three are the same upstream issue (GHSA-frvp-7c67-39w9) counted at three levels of one chain:

```
@fozikio/cortex-engine
└── @modelcontextprotocol/sdk@1.29.0   (latest)
    └── @hono/node-server ^1.19.9      ← GHSA-frvp-7c67-39w9
```

**Not fixable downstream.** The advisory's first patched version is 2.0.5, a major bump the MCP SDK has not taken; 1.29.0 is current latest and still pins `^1.19.9`.

**Not reachable here.** cortex-engine never imports hono — it arrives only as a transitive dep of the MCP SDK, and our MCP server runs over stdio, which never mounts `serve-static`. Dashboard static serving is our own `serveStatic` in `src/rest/server.ts`, which resolves and containment-checks with `path.relative` and explicitly handles the Windows backslash case this advisory is about.

Adds a **Known advisories** subsection under Security so users running `npm audit` get an answer inline, and so this assessment stops being re-derived from scratch on each ecosystem health check (it has now been re-analyzed on 07-06, 07-24, and 07-27).

Docs-only change.