### PR TITLE
chore(release): 1.4.0 — the silent-failure release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+## [1.4.0] — 2026-07-30
+
+### The silent-failure release
+
+Every fix here addresses the same shape of bug: a mechanism that reported success, or reported nothing at all, while doing nothing. An identity ledger whose entries could never leave `proposed`. LLM calls that spent their whole token budget on hidden reasoning and returned an empty string. Two separate guards against exactly that, both inert — one matching a tag format the provider no longer emits, the other a soft switch the model no longer honours, sitting under a comment asserting it worked. Consolidation monitoring that read a timestamp nothing ever wrote, so a store with 3,131 processed observations was indistinguishable from one that had never consolidated at all.
+
+None of these announced themselves, and each was found by checking a mechanism against reality rather than reading its description. That is the same principle the new service supervision applies at runtime: a service is up when its endpoint answers, not when its process exists.
+
 ### Added
 
 - **Service supervision** (`src/services/`) — `fozikio` now manages the two daemons the default install depends on: ollama and the bundled NLI cross-encoder. `up`, `down`, `status`, and `service <start|stop|restart|status|logs>` spawn them detached, capture output to `~/.fozikio/logs/`, track PIDs in `~/.fozikio/run/`, and wait on an HTTP probe before reporting ready. `up --watch` supervises continuously: exponential backoff, a circuit breaker after five failed restarts, and a notification hook (`FOZIKIO_NOTIFY_URL` / `FOZIKIO_NOTIFY_CMD`) so repeated restarts escalate rather than being hidden. **A service is up when its endpoint answers, not when its process exists** — a live process that has stopped responding reports `degraded`. That is the failure this exists to catch: ollama dies silently, every semantic tool then fails while ops, threads and journal keep working, and the outage reads as "cortex is fine" until a query comes back empty. Services started outside fozikio are reported as such and are never killed.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fozikio/cortex-engine",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fozikio/cortex-engine",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
         "@fozikio/reflex": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fozikio/cortex-engine",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Portable cognitive engine for AI agents — storage, embeddings, memory, FSRS, and MCP server",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Promotes `[Unreleased]` to `[1.4.0]`, bumps `package.json` and `package-lock.json` (the lockfile still read 1.3.0 in both of its version fields after the manual bump).

## What ships

- **#47** — service supervision, `fozikio doctor`, interactive shell, dashboard, noun-verb command tree. Also fixes CI having run `tsc` only, on ubuntu only: the vitest suite was configured but never executed by the merge gate.
- **#48** — `evolution_resolve`, so identity evolutions can leave `proposed`. Tool count 59 → 60.
- **#49** — Ollama `think: false`. The highest-impact fix here: on the default model every bounded LLM call was returning empty or truncated output.
- **#50** — `dream` records each run, so consolidation monitoring can report a real last-dream time.

## Theme

Every fix addresses the same shape of bug — a mechanism that reported success, or reported nothing at all, while doing nothing. Three of the four were found by checking a mechanism against reality rather than reading its description.

## Verification

- `npm run build` — tsc clean at 1.4.0
- `npm test` — 308 tests across 35 files, all passing
- 60 tools registered, `evolution_resolve` present

After merge, tagging `v1.4.0` triggers `publish.yml`, which publishes via OIDC trusted publishing (no token) and auto-creates the GitHub Release from this CHANGELOG.