### PR TITLE
fix(docker): the published image started stdio MCP, so it bound no port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,4 +33,8 @@ RUN npm ci --omit=dev
 COPY --from=builder /app/dist ./dist
 
 EXPOSE 8080
-CMD ["node", "dist/bin/serve.js"]
+# The image exists to serve the REST API (EXPOSE 8080 / docker-compose maps 8080).
+# Without --rest this starts the stdio MCP server, which binds no port.
+# HOST/PORT are read by serve.js; 0.0.0.0 is required to be reachable outside the container.
+ENV HOST=0.0.0.0
+CMD ["node", "dist/bin/serve.js", "--rest"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@
 #
 # Connect to Claude Code MCP:
 #   Add to .mcp.json: { "cortex": { "url": "http://localhost:8080" } }
+#
+# Requires CORTEX_API_TOKEN in the environment; requests send it as x-cortex-token.
 
 services:
   cortex:
@@ -18,6 +20,9 @@ services:
       NODE_ENV: development
       CORS_ORIGINS: "*"
       CORTEX_INSTANCE_NAME: cortex
+      # The REST server refuses to start without a token (or --allow-unauthenticated).
+      # Export CORTEX_API_TOKEN before `docker compose up`.
+      CORTEX_API_TOKEN: ${CORTEX_API_TOKEN:?set CORTEX_API_TOKEN before starting}
     depends_on:
       - firestore
     restart: unless-stopped

--- a/src/bin/serve.ts
+++ b/src/bin/serve.ts
@@ -36,7 +36,9 @@ const useRest = process.argv.includes('--rest');
 const portIdx = process.argv.indexOf('--port');
 const restPort = portIdx !== -1 && process.argv[portIdx + 1]
   ? parseInt(process.argv[portIdx + 1], 10)
-  : 3000;
+  : process.env['PORT']
+    ? parseInt(process.env['PORT'], 10)
+    : 3000;
 const tokenIdx = process.argv.indexOf('--token');
 const restToken = tokenIdx !== -1 && process.argv[tokenIdx + 1]
   ? process.argv[tokenIdx + 1]
@@ -44,7 +46,7 @@ const restToken = tokenIdx !== -1 && process.argv[tokenIdx + 1]
 const hostIdx = process.argv.indexOf('--host');
 const restHost = hostIdx !== -1 && process.argv[hostIdx + 1]
   ? process.argv[hostIdx + 1]
-  : undefined;
+  : process.env['HOST'];
 const allowUnauthenticated = process.argv.includes('--allow-unauthenticated');
 const allowCorsLocalhost = process.argv.includes('--allow-cors-localhost');
 


### PR DESCRIPTION
The published container image cannot serve. `EXPOSE 8080`, `ENV PORT=8080`, and `docker-compose.yml` (which maps 8080 and whose header says *Cortex API: http://localhost:8080*) all promise an HTTP API, but `CMD` ran `dist/bin/serve.js` with no `--rest` — which starts the **stdio MCP server**. A container pulled from `ghcr.io/fozikio/cortex-engine:latest` binds no port at all, so the documented `docker compose up -d` quick start has never produced a reachable API.

Adding `--rest` alone would not have fixed it. Two further mismatches sat underneath:

- **`PORT` was dead config.** `serve.js` defaults the REST port to `3000` and never reads `process.env.PORT`. The Dockerfile has set `ENV PORT=8080` since it was written, and nothing consumed it — so even with `--rest`, the container would have listened on 3000 behind an `EXPOSE 8080`.
- **The bind address is loopback.** `startRestServer` defaults to `127.0.0.1`, which is unreachable from outside a container regardless of port mapping.

## Changes

- `src/bin/serve.ts` — `PORT` and `HOST` now supply the REST defaults. `--port` / `--host` still take precedence, and the non-container default is unchanged (`3000` / `127.0.0.1`), so nothing changes for `npx fozikio serve --rest` users.
- `Dockerfile` — `CMD` gains `--rest`; `ENV HOST=0.0.0.0`. Comment explains why both are needed, so the next reader doesn't drop them.
- `docker-compose.yml` — passes `CORTEX_API_TOKEN`, which the REST server requires. Uses the `${VAR:?}` form so a missing token fails at `up` with a clear message instead of the container exiting on a startup error.

## Verification

Built clean (`tsc`), full suite green (35 files / 326 tests), and the binary exercised directly rather than inferred:

```
$ PORT=8080 CORTEX_API_TOKEN=… node dist/bin/serve.js --rest
  rest api ready · http://127.0.0.1:8080
  13 tools · auth enabled

$ curl -s localhost:8080/health
{"status":"ok","version":"1.4.1","store":"sqlite","tools":13}

$ curl -o/dev/null -w '%{http_code}' -H 'x-cortex-token: …' localhost:8080/api/stats
200
$ curl -o/dev/null -w '%{http_code}' localhost:8080/api/stats
401
```

On master that same command binds 3000, not 8080.

## Left deliberately out of scope

`docker-compose.yml` still sets `FIRESTORE_EMULATOR_HOST` and `GCP_PROJECT_ID` and depends on a firestore service, but the container finds no config file and falls back to `DEFAULT_CONFIG` (sqlite + ollama) — and no ollama service is defined in the compose stack. So the compose file now *serves*, but it serves a sqlite-backed engine whose semantic tools have no LLM behind them, not the Firestore-backed one it appears to describe. That needs a decision about what the quick start is meant to demonstrate rather than a mechanical fix, and it is a separate change from making the image bind a port at all.

Found by the scheduled ecosystem health check.
