### PR TITLE
chore(deps): drop the openai and @anthropic-ai/sdk peers; nothing imports them

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,14 +19,12 @@
         "fozikio": "dist/bin/cli.js"
       },
       "devDependencies": {
-        "@anthropic-ai/sdk": "^0.39.0",
         "@google-cloud/aiplatform": "^3.12.0",
         "@google-cloud/firestore": "^7.11.0",
         "@google-cloud/vertexai": "^1.9.0",
         "@types/better-sqlite3": "^7.6.12",
         "@types/node": "^22.10.0",
         "firebase-admin": "^13.0.0",
-        "openai": "^4.77.0",
         "typescript": "^5.7.0",
         "vitest": "^4.1.0"
       },
@@ -38,18 +36,13 @@
         "url": "https://github.com/sponsors/idapixl"
       },
       "peerDependencies": {
-        "@anthropic-ai/sdk": "^0.39.0",
         "@google-cloud/aiplatform": "^3.12.0",
         "@google-cloud/firestore": "^7.11.0",
         "@google-cloud/vertexai": "^1.9.0",
         "@huggingface/transformers": "^3.8.1",
-        "firebase-admin": "^13.0.0",
-        "openai": "^4.77.0"
+        "firebase-admin": "^13.0.0"
       },
       "peerDependenciesMeta": {
-        "@anthropic-ai/sdk": {
-          "optional": true
-        },
         "@google-cloud/aiplatform": {
           "optional": true
         },
@@ -64,44 +57,8 @@
         },
         "firebase-admin": {
           "optional": true
-        },
-        "openai": {
-          "optional": true
         }
       }
-    },
-    "node_modules/@anthropic-ai/sdk": {
-      "version": "0.39.0",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.39.0.tgz",
-      "integrity": "sha512-eMyDIPRZbt1CCLErRCi3exlAvNkBtRe+kW5vvJyef93PmNr/clstYgHhtvmkxN82nlKgzyGPCyGxrm0JQ1ZIdg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "^18.11.18",
-        "@types/node-fetch": "^2.6.4",
-        "abort-controller": "^3.0.0",
-        "agentkeepalive": "^4.2.1",
-        "form-data-encoder": "1.7.2",
-        "formdata-node": "^4.3.2",
-        "node-fetch": "^2.6.7"
-      }
-    },
-    "node_modules/@anthropic-ai/sdk/node_modules/@types/node": {
-      "version": "18.19.130",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
-      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~5.26.4"
-      }
-    },
-    "node_modules/@anthropic-ai/sdk/node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@emnapi/core": {
       "version": "1.10.0",
@@ -1195,17 +1152,6 @@
         "undici-types": "~6.21.0"
       }
     },
-    "node_modules/@types/node-fetch": {
-      "version": "2.6.13",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
-      "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "form-data": "^4.0.4"
-      }
-    },
     "node_modules/@types/request": {
       "version": "2.48.13",
       "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.13.tgz",
@@ -1414,19 +1360,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14"
-      }
-    },
-    "node_modules/agentkeepalive": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
-      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "humanize-ms": "^1.2.1"
-      },
-      "engines": {
-        "node": ">= 8.0.0"
       }
     },
     "node_modules/ajv": {
@@ -2420,67 +2353,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/form-data": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
-      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.4",
-        "mime-types": "^2.1.35"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/form-data-encoder": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
-      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/form-data/node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/form-data/node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/formdata-node": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
-      "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "node-domexception": "1.0.0",
-        "web-streams-polyfill": "4.0.0-beta.3"
-      },
-      "engines": {
-        "node": ">= 12.20"
-      }
-    },
     "node_modules/formdata-polyfill": {
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
@@ -2980,16 +2852,6 @@
       },
       "engines": {
         "node": ">= 14"
-      }
-    },
-    "node_modules/humanize-ms": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
-      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.0.0"
       }
     },
     "node_modules/iconv-lite": {
@@ -3862,54 +3724,6 @@
       "dependencies": {
         "wrappy": "1"
       }
-    },
-    "node_modules/openai": {
-      "version": "4.104.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-4.104.0.tgz",
-      "integrity": "sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@types/node": "^18.11.18",
-        "@types/node-fetch": "^2.6.4",
-        "abort-controller": "^3.0.0",
-        "agentkeepalive": "^4.2.1",
-        "form-data-encoder": "1.7.2",
-        "formdata-node": "^4.3.2",
-        "node-fetch": "^2.6.7"
-      },
-      "bin": {
-        "openai": "bin/cli"
-      },
-      "peerDependencies": {
-        "ws": "^8.18.0",
-        "zod": "^3.23.8"
-      },
-      "peerDependenciesMeta": {
-        "ws": {
-          "optional": true
-        },
-        "zod": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/openai/node_modules/@types/node": {
-      "version": "18.19.130",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
-      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~5.26.4"
-      }
-    },
-    "node_modules/openai/node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/p-limit": {
       "version": "3.1.0",
@@ -5157,16 +4971,6 @@
         "vite": {
           "optional": false
         }
-      }
-    },
-    "node_modules/web-streams-polyfill": {
-      "version": "4.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
-      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
       }
     },
     "node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -28,18 +28,13 @@
     "yaml": "^2.7.0"
   },
   "peerDependencies": {
-    "@anthropic-ai/sdk": "^0.39.0",
     "@google-cloud/aiplatform": "^3.12.0",
     "@google-cloud/firestore": "^7.11.0",
     "@google-cloud/vertexai": "^1.9.0",
     "@huggingface/transformers": "^3.8.1",
-    "firebase-admin": "^13.0.0",
-    "openai": "^4.77.0"
+    "firebase-admin": "^13.0.0"
   },
   "peerDependenciesMeta": {
-    "@anthropic-ai/sdk": {
-      "optional": true
-    },
     "@google-cloud/aiplatform": {
       "optional": true
     },
@@ -54,20 +49,15 @@
     },
     "firebase-admin": {
       "optional": true
-    },
-    "openai": {
-      "optional": true
     }
   },
   "devDependencies": {
-    "@anthropic-ai/sdk": "^0.39.0",
     "@google-cloud/aiplatform": "^3.12.0",
     "@google-cloud/firestore": "^7.11.0",
     "@google-cloud/vertexai": "^1.9.0",
     "@types/better-sqlite3": "^7.6.12",
     "@types/node": "^22.10.0",
     "firebase-admin": "^13.0.0",
-    "openai": "^4.77.0",
     "typescript": "^5.7.0",
     "vitest": "^4.1.0"
   },


### PR DESCRIPTION
Closes the recurring "`openai` 4.x → 7.x peer-range decision" the weekly audit has raised for several weeks. The answer turned out not to be a range.

## Finding

`openai` and `@anthropic-ai/sdk` are declared as optional `peerDependencies` (mirrored into `devDependencies`) but **are never imported anywhere in this package**. Verified exhaustively across static `import`, `require()`, and `await import()` forms over all tracked sources — zero references to either.

They are vestigial because both providers speak HTTP directly:

- `src/providers/openai-compatible.ts` states it in its own header — *"Uses native fetch — no SDK dependency required"* — and calls `fetch(${baseUrl}/chat/completions)`.
- `src/mcp/server.ts:355` routes the `anthropic` config value through that **same** adapter: *"Both use the OpenAI-compatible adapter — Anthropic's API is close enough for simple generate() calls."*

## Why this was not harmless

Leaving them cost two things:

1. **A false peer contract.** Consumers were told to supply SDKs for functionality that requires none.
2. **A recurring audit finding.** `openai` drifting across two majors generated a weekly "peer-range widening decision for owner" item — deliberating a range for a dependency with no call sites. This retires it permanently instead of re-litigating it each week.

## Scope

Removed from `peerDependencies`, `peerDependenciesMeta`, and `devDependencies`. The lockfile drops 198 lines as their transitive trees go with them.

The five remaining optional peers **are** genuinely used via dynamic import and are untouched: `@google-cloud/aiplatform`, `@google-cloud/vertexai`, `@google-cloud/firestore`, `firebase-admin`, `@huggingface/transformers`.

## Verification

- `npm run build` (`tsc --noEmit && tsc`) — clean
- `npm test` — **326 tests across 35 files passing**

No source files changed.