### PR TITLE
ci: add audit and Node 20 gates; add SECURITY, CONTRIBUTING, CODEOWNERS, dependabot

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# Default owner for everything in this repository.
+* @idapixl
+
+# Anything that can ship code to consumers or alter the trust boundary
+# warrants explicit review even when the diff looks mechanical.
+/.github/workflows/  @idapixl
+/Dockerfile          @idapixl
+/scripts/            @idapixl
+/package.json        @idapixl

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    groups:
+      # One PR per ecosystem bump keeps the weekly audit from having to
+      # reconcile a dozen separate lockfile branches against each other.
+      production-dependencies:
+        dependency-type: production
+      development-dependencies:
+        dependency-type: development
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    commit-message:
+      prefix: "ci"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,3 +43,35 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm test
+
+  # Gates on high/critical only. Moderates are deliberately not a merge
+  # blocker: some transitive advisories have no fix reachable without
+  # breaking changes, and a gate that cannot be satisfied gets ignored or
+  # bypassed rather than fixed. High and above must stay at zero.
+  audit:
+    name: Audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+      - run: npm ci
+      - run: npm audit --audit-level=high
+
+  # package.json claims `engines: node >=20`, but every other job runs 24,
+  # so the claim was never tested. This job is the evidence for it. If it
+  # fails, the honest fix is to raise `engines` — not to delete this job.
+  node20:
+    name: Node 20 Compat
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - run: npm test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,86 @@
+# Contributing
+
+## Getting set up
+
+```bash
+npm ci
+npm run build     # tsc
+npm test          # vitest, 326 tests
+```
+
+Node 20 or newer (`engines: node >=20`). CI runs the suite on Node 24 across
+Ubuntu and Windows, and separately checks that the package still builds and
+tests on Node 20 so the published `engines` claim stays honest.
+
+Windows is in the test matrix on purpose: service supervision is
+platform-specific — detached spawning, `taskkill` and PID handling all differ
+there — and an Ubuntu-only gate cannot see any of it.
+
+## Before you open a PR
+
+```bash
+npm run build            # must be clean
+npm test                 # must be green
+npm audit --audit-level=high
+npm run verify:package   # only if you touched `files` or the build output
+```
+
+`verify:package` exists because the web dashboard silently stopped shipping at
+1.2.2 — a `files` entry was omitted and nothing caught it. If you add an asset
+that must reach the published tarball, **the `files` entry and the build step
+that produces it have to land in the same PR.** Adding the entry first fails
+the publish; adding the build step first silently ships nothing.
+
+## Commit messages
+
+Conventional Commits, with a scope where it adds clarity:
+
+```
+type(scope): summary
+```
+
+Types: `feat`, `fix`, `chore`, `docs`, `refactor`, `test`, `ci`, `build`,
+`perf`, `security`, `style`, `revert`.
+
+The body should explain **why**. The diff already shows what changed. A commit
+that fixes a subtle bug should leave behind the reasoning that made it subtle,
+not a restatement of the patch.
+
+## Pull requests
+
+This repository is on the **Production** workflow tier:
+
+- No direct pushes to `master` — every change goes through a PR.
+- CI is a hard merge gate. The required context is **`Type Check`**; do not
+  rename that job, or branch protection will wait forever on a check that no
+  longer reports.
+- Branches must be up to date with `master` before merging.
+
+## Dependencies
+
+Security fixes are preferred as lockfile-only changes (`npm audit fix` without
+`--force`). Two cautions learned the hard way:
+
+- **`npm audit fix --force` will propose downgrades.** It suggests the newest
+  version its advisory data marks clean, which can be several majors *below*
+  what you run. Read the proposed version before accepting it.
+- **A green audit is not proof of a working tree.** A dependency whose fix
+  shipped alongside an ESM migration can satisfy `npm audit` and `tsc` while
+  throwing at runtime for CommonJS callers. Run the suite after any override.
+
+Use `overrides` to pin a transitive dependency; several are already in place.
+
+## Optional peer dependencies
+
+Cloud and embedding providers are optional peers loaded through dynamic
+`import()`. If you add one, it must be:
+
+1. listed in `peerDependencies` **and** `peerDependenciesMeta` as optional,
+2. mirrored into `devDependencies` so tests can exercise it, and
+3. **actually imported.**
+
+Point 3 is not rhetorical — `openai` and `@anthropic-ai/sdk` sat in all three
+lists for months while nothing imported them, because both providers speak
+HTTP through `providers/openai-compatible.ts` via native `fetch`. They
+generated a recurring dependency-drift finding for a decision that did not
+exist. Declare a peer only when something loads it.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,47 @@
+# Security Policy
+
+## Supported versions
+
+Security fixes land on the latest published minor. `@fozikio/cortex-engine`
+is currently at **1.4.1**; older minors are not backported.
+
+| Version | Supported |
+| ------- | --------- |
+| 1.4.x   | Yes       |
+| < 1.4   | No        |
+
+## Reporting a vulnerability
+
+**Do not open a public issue for a security problem.**
+
+Report privately through GitHub's
+[Private vulnerability reporting](https://github.com/Fozikio/cortex-engine/security/advisories/new)
+on this repository. That routes straight to the maintainers and keeps the
+details unpublished until a fix is available.
+
+Please include:
+
+- what an attacker can achieve, not only what is technically wrong
+- the affected version and how the package is being consumed
+  (library import, `serve --rest`, stdio MCP server, or the Docker image)
+- a minimal reproduction, if you have one
+
+You can expect an acknowledgement within a week. If a report is confirmed,
+we will agree a disclosure timeline with you before publishing.
+
+## Scope notes
+
+A few things are worth stating up front, because they are properties of the
+design rather than defects:
+
+- **Optional peer dependencies are loaded via dynamic `import()`.** Cloud
+  and embedding providers are only pulled in when configured. A consumer that
+  installs none of them never loads that code.
+- **The REST server binds `0.0.0.0` in the Docker image** so the container is
+  reachable. It performs no authentication of its own. Do not expose it
+  directly to an untrusted network — put it behind something that
+  authenticates.
+- **Config files can carry API keys.** `config-loader` deliberately warns when
+  it finds `openai_api_key` in a config file rather than the environment.
+  Reports that keys in a config file are readable by that file's readers are
+  not vulnerabilities.


### PR DESCRIPTION
Closes the repository-hygiene backlog left open by the #58/#60 audit.

## CI gates

**`Audit` — `npm audit --audit-level=high`**
CI never ran `npm audit`. A new advisory only surfaced when the weekly cloud audit noticed it, which meant a **five-week blind spot** while that routine was failing silently.

Gates on **high and above deliberately, not moderate**. Some transitive advisories have no fix reachable without breaking changes (see idapixl-cortex #41 for a worked example), and a gate that cannot be satisfied gets bypassed rather than fixed. Verified: this repo is at **0 vulnerabilities**, so the gate lands green and locks in the current state.

**`Node 20 Compat`**
`package.json` claims `engines: node >=20`, but every CI job ran Node 24 — the claim was never tested and consumers on 20 were trusting an unverified promise. This job is the evidence for it.

> If it fails, the honest fix is to raise `engines`, not to delete the job.

Kept as a **separate job rather than a matrix dimension** on `Test`: expanding that matrix renames its check contexts (`Test (ubuntu-latest)` → `Test (ubuntu-latest, 20)`). Branch protection currently requires only `Type Check`, but the existing in-file comment warns about exactly this class of breakage, so I stayed on the safe side.

## New files

| File | Why |
|---|---|
| `.github/dependabot.yml` | npm + github-actions, weekly. **Grouped** into one production and one development PR so the weekly audit does not have to reconcile a dozen competing lockfile branches. |
| `SECURITY.md` | Routes reports to private vulnerability reporting instead of public issues. |
| `CONTRIBUTING.md` | Preserves reasoning currently living only in PR history. |
| `.github/CODEOWNERS` | Default owner, plus explicit coverage of paths that ship code or move the trust boundary. |

`SECURITY.md` also records three properties that are **design, not defects**, so they stop being re-reported: optional peers load via dynamic `import()`; the REST server has no auth of its own and must sit behind something that does; config files may hold API keys by design.

`CONTRIBUTING.md` captures the institutional knowledge this repo has paid for:

- why `verify:package` exists, and that a `files` entry **must land in the same PR** as the build step producing it — the constraint from #60 that is otherwise only in #59
- why Windows is in the test matrix (service supervision differs: detached spawning, `taskkill`, PID handling)
- that `Type Check` must not be renamed
- the two dependency traps already hit here: `audit fix --force` proposing *downgrades*, and a green audit plus clean typecheck **still** breaking at runtime

## Deliberately not included

**No linter.** This package has no lint tooling at all, so adding one means picking a config and fixing every resulting violation — a separate change deserving its own reviewable diff, not a rider on a hygiene PR.

**No Dockerfile changes.** The runtime stage ships its build toolchain and runs as root; both are real, but the non-root switch interacts with the default `./cortex.db` write path and needs a runtime smoke test. Handled separately.