### PR TITLE
fix(deps): the README still tells users to expect three advisories that are gone

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,21 +59,14 @@ The engine includes defense-in-depth protections for deployed environments:
 
 ### Known advisories
 
-`npm install @fozikio/cortex-engine` currently reports **3 moderate advisories**. All three are the same upstream issue counted at three levels of one dependency chain, and none are reachable in this package:
+`npm install @fozikio/cortex-engine` reports **0 vulnerabilities**.
 
-```
-@fozikio/cortex-engine
-└── @modelcontextprotocol/sdk@1.29.0   (latest)
-    └── @hono/node-server ^1.19.9      ← GHSA-frvp-7c67-39w9
-```
-
-**What it is:** path traversal in `@hono/node-server`'s `serve-static` middleware on Windows, via an encoded backslash (`%5C`).
-
-**Why it isn't fixed:** the advisory's first patched version is `2.0.5` — a major-version bump the MCP SDK has not taken. `@modelcontextprotocol/sdk@1.29.0` is the current latest and still pins `^1.19.9`, so there is no remediation available downstream. Forcing `2.x` via an override would break the SDK's expected API.
-
-**Why it doesn't affect you:** cortex-engine never imports hono. `@hono/node-server` is pulled in only as a transitive dependency of the MCP SDK, and the MCP server here runs over **stdio transport**, which never mounts `serve-static`. The REST server's static file serving is our own implementation ([`src/rest/server.ts`](src/rest/server.ts)), which resolves paths and verifies containment with `path.relative` before reading — explicitly handling the Windows backslash case this advisory describes. It also serves nothing by default: the published package ships no static assets, so the path is inert unless you supply your own.
-
-This will clear on its own once the MCP SDK adopts `@hono/node-server` 2.x. Until then, `npm audit` noise from this chain is expected and safe to ignore.
+This section previously documented three moderate advisories from
+`@hono/node-server`, pulled in transitively by the MCP SDK and unreachable here
+(the MCP server runs over stdio, which never mounts `serve-static`). That chain
+has since been fixed upstream: `@modelcontextprotocol/sdk@1.30.0` accepts
+`@hono/node-server` `^2.0.5`, and this package now requires SDK `^1.30.0` so the
+patched range resolves for every install rather than by chance.
 
 ## Architecture
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@fozikio/cortex-engine",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fozikio/cortex-engine",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "license": "MIT",
       "dependencies": {
         "@fozikio/reflex": "^0.2.0",
-        "@modelcontextprotocol/sdk": "^1.29.0",
+        "@modelcontextprotocol/sdk": "^1.30.0",
         "better-sqlite3": "^11.7.0",
         "yaml": "^2.7.0"
       },
@@ -614,12 +614,12 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
-      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
       "license": "MIT",
       "dependencies": {
-        "@hono/node-server": "^1.19.9",
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fozikio/cortex-engine",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Portable cognitive engine for AI agents — storage, embeddings, memory, FSRS, and MCP server",
   "type": "module",
   "main": "dist/index.js",
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@fozikio/reflex": "^0.2.0",
-    "@modelcontextprotocol/sdk": "^1.29.0",
+    "@modelcontextprotocol/sdk": "^1.30.0",
     "better-sqlite3": "^11.7.0",
     "yaml": "^2.7.0"
   },


### PR DESCRIPTION
**The finding.** The README's *Known advisories* section documents three moderate `@hono/node-server` advisories (GHSA-frvp-7c67-39w9) and states there is "no remediation available downstream". Verified against a clean install in a temp dir this run:

```
npm install @fozikio/cortex-engine
found 0 vulnerabilities
```

The section's own exit condition has been met — it said the issue would clear once the MCP SDK adopted `@hono/node-server` 2.x, and `@modelcontextprotocol/sdk@1.30.0` now declares `"@hono/node-server": "^1.19.9 || ^2.0.5"`.

Leaving it is worse than a merely stale doc: a reader comparing the README against their own clean audit has to decide which is lying, and the closing line — that noise from this chain is "expected and safe to ignore" — teaches people to ignore a signal that is now real.

**The dependency change.** Raising the SDK floor from `^1.29.0` to `^1.30.0` makes the clean audit a property of the package rather than a coincidence of install timing. At `^1.29.0` a resolver honouring an older lockfile still lands in the vulnerable range.

**The release.** Cuts 1.4.2. npm has been on 1.4.1 since 2026-08-01 — 40 days — while master accumulated six commits, three of them user-facing fixes: the dream placeholder/markdown leak (#58), silently omitted `files` entries (#60), and the published Docker image that bound no port (#61).

**Verified locally:** `npm ci` → `tsc` clean → 326/326 tests → `npm audit --omit=dev` 0 vulnerabilities.